### PR TITLE
fix: fix slack channel hardcoding in skipLoop

### DIFF
--- a/src/types/arbitrage/skipLoop.ts
+++ b/src/types/arbitrage/skipLoop.ts
@@ -178,7 +178,7 @@ export class SkipLoop extends MempoolLoop {
 			});
 		}
 		console.log(slackMessage);
-		await sendSlackMessage(slackMessage, this.slackLogger, "logging");
+		await sendSlackMessage(slackMessage, this.slackLogger, this.botConfig.slackChannel);
 		if (res.result.code === 0) {
 			this.sequence += 1;
 		} else {


### PR DESCRIPTION
## Description and Motivation

Fixed hardcoding to slack channel "logging", changed to use `botConfig.slackChannel`

## Related Issues

n/a


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
