### PR TITLE
feat: added removal of pools not used in any path

### DIFF
--- a/src/types/core/pool.ts
+++ b/src/types/core/pool.ts
@@ -250,13 +250,13 @@ export function getAssetsOrder(pool: Pool, assetInfo: AssetInfo) {
  * @returns Filtered array of Pools.
  */
 export function removedUnusedPools(pools: Array<Pool>, paths: Array<Path>): Array<Pool> {
-	const filteredPools: Array<Pool> = [];
+	const filteredPools: Set<Pool> = new Set();
 	pools.forEach((pool) =>
 		paths.forEach((path) => {
 			if (path.pools.find((pathPool) => pathPool.address === pool.address) !== undefined) {
-				filteredPools.push(pool);
+				filteredPools.add(pool);
 			}
 		}),
 	);
-	return [...new Set(filteredPools)];
+	return [...filteredPools];
 }

--- a/src/types/core/pool.ts
+++ b/src/types/core/pool.ts
@@ -250,13 +250,8 @@ export function getAssetsOrder(pool: Pool, assetInfo: AssetInfo) {
  * @returns Filtered array of Pools.
  */
 export function removedUnusedPools(pools: Array<Pool>, paths: Array<Path>): Array<Pool> {
-	const filteredPools: Set<Pool> = new Set();
-	pools.forEach((pool) =>
-		paths.forEach((path) => {
-			if (path.pools.find((pathPool) => pathPool.address === pool.address) !== undefined) {
-				filteredPools.add(pool);
-			}
-		}),
+	const filteredPools: Set<Pool> = new Set(
+		pools.filter((pool) => paths.some((path) => path.pools.some((pathPool) => pathPool.address === pool.address))),
 	);
 	return [...filteredPools];
 }

--- a/src/types/core/pool.ts
+++ b/src/types/core/pool.ts
@@ -11,6 +11,7 @@ import {
 } from "../messages/swapmessages";
 import { Asset, AssetInfo, isMatchingAssetInfos, isWyndDaoNativeAsset } from "./asset";
 import { MempoolTrade } from "./mempool";
+import { Path } from "./path";
 import { Uint128 } from "./uint128";
 
 export enum AmmDexName {
@@ -240,4 +241,22 @@ export function getAssetsOrder(pool: Pool, assetInfo: AssetInfo) {
 	} else if (isMatchingAssetInfos(pool.assets[1].info, assetInfo)) {
 		return [pool.assets[1], pool.assets[0]] as Array<Asset>;
 	}
+}
+
+/**
+ * Function to remove pools that are not used in paths.
+ * @param pools Array of Pool types to check for filtering.
+ * @param paths Array of Path types to check the pools against.
+ * @returns Filtered array of Pools.
+ */
+export function removedUnusedPools(pools: Array<Pool>, paths: Array<Path>): Array<Pool> {
+	const filteredPools: Array<Pool> = [];
+	pools.forEach((pool) =>
+		paths.forEach((path) => {
+			if (path.pools.find((pathPool) => pathPool.address === pool.address) !== undefined) {
+				filteredPools.push(pool);
+			}
+		}),
+	);
+	return [...new Set(filteredPools)];
 }


### PR DESCRIPTION
This PR implements a filter function that filters the used pools for usage in any paths. If a pool is not used in any of our constructed paths it is removed from the pool array to prevent it from being queried. 
#34 
- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
