### PR TITLE
Update Release from Main. Add Bug/profit calculation and path cooldown (#50)

### DIFF
--- a/src/core/arbitrage/arbitrage.ts
+++ b/src/core/arbitrage/arbitrage.ts
@@ -1,4 +1,4 @@
-import { Asset, isNativeAsset } from "../types/base/asset";
+import { Asset } from "../types/base/asset";
 import { BotConfig } from "../types/base/botConfig";
 import { Path } from "../types/base/path";
 import { getOptimalTrade } from "./optimizers/analyticalOptimizer";
@@ -12,34 +12,33 @@ export interface OptimalTrade {
  *
  */
 export function trySomeArb(paths: Array<Path>, botConfig: BotConfig): OptimalTrade | undefined {
-	const [path, tradesize, profit] = getOptimalTrade(paths, botConfig.offerAssetInfo);
+	const optimalTrade: OptimalTrade | undefined = getOptimalTrade(paths, botConfig.offerAssetInfo);
 
-	if (path === undefined) {
+	if (!optimalTrade) {
 		return undefined;
 	} else {
-		const profitThreshold =
-			botConfig.profitThresholds.get(path.pools.length) ??
-			Array.from(botConfig.profitThresholds.values())[botConfig.profitThresholds.size];
-		if (profit < profitThreshold) {
+		if (!isAboveThreshold(botConfig, optimalTrade)) {
 			return undefined;
 		} else {
-			console.log("optimal tradesize: ", tradesize, " with profit: ", profit);
-			console.log("path: "),
-				path.pools.map((pool) => {
-					console.log(
-						pool.address,
-						isNativeAsset(pool.assets[0].info)
-							? pool.assets[0].info.native_token.denom
-							: pool.assets[0].info.token.contract_addr,
-						pool.assets[0].amount,
-						isNativeAsset(pool.assets[1].info)
-							? pool.assets[1].info.native_token.denom
-							: pool.assets[1].info.token.contract_addr,
-						pool.assets[1].amount,
-					);
-				});
-			const offerAsset: Asset = { amount: String(tradesize), info: botConfig.offerAssetInfo };
-			return { path, offerAsset, profit };
+			return optimalTrade;
 		}
 	}
+}
+
+/**
+ *
+ */
+function isAboveThreshold(botConfig: BotConfig, optimalTrade: OptimalTrade): boolean {
+	// We dont know the number of message required to execute the trade, so the profit threshold will be set to the most conservative value: nr_of_pools*2-1
+	const profitThreshold =
+		botConfig.profitThresholds.get((optimalTrade.path.pools.length - 1) * 2 + 1) ??
+		Array.from(botConfig.profitThresholds.values())[botConfig.profitThresholds.size - 1];
+	if (botConfig.skipConfig) {
+		const skipBidRate = botConfig.skipConfig.skipBidRate;
+		return (
+			(1 - skipBidRate) * optimalTrade.profit - (botConfig.flashloanFee / 100) * +optimalTrade.offerAsset.amount >
+			profitThreshold
+		); //profit - skipbid*profit - flashloanfee*tradesize must be bigger than the set PROFIT_THRESHOLD + TX_FEE. The TX fees dont depend on tradesize nor profit so are set in config
+	} else
+		return optimalTrade.profit - (botConfig.flashloanFee / 100) * +optimalTrade.offerAsset.amount > profitThreshold;
 }

--- a/src/core/arbitrage/graph.ts
+++ b/src/core/arbitrage/graph.ts
@@ -90,6 +90,7 @@ export function getPaths(graph: Graph, startingAsset: AssetInfo, depth: number):
 		}
 		paths.push({
 			pools: poolList,
+			cooldown: false,
 		});
 	}
 	return paths;

--- a/src/core/types/base/botConfig.ts
+++ b/src/core/types/base/botConfig.ts
@@ -1,4 +1,4 @@
-import { Coin, StdFee } from "@cosmjs/stargate";
+import { StdFee } from "@cosmjs/stargate";
 import { assert } from "console";
 
 import { NativeAssetInfo } from "./asset";
@@ -16,6 +16,7 @@ export interface BotConfig {
 	maxPathPools: number;
 	mappingFactoryRouter: Array<{ factory: string; router: string }>;
 	flashloanRouterAddress: string;
+	flashloanFee: number;
 	offerAssetInfo: NativeAssetInfo;
 	mnemonic: string;
 	useMempool: boolean;
@@ -64,23 +65,15 @@ export function setBotConfig(envs: NodeJS.ProcessEnv): BotConfig {
 			skipBidRate: envs.SKIP_BID_RATE === undefined ? 0 : +envs.SKIP_BID_RATE,
 		};
 	}
-	const FLASHLOAN_FEE = +envs.FLASHLOAN_FEE;
 	const PROFIT_THRESHOLD = +envs.PROFIT_THRESHOLD;
 
 	//set all required fees for the depth of the hops set by user;
-	const GAS_FEES = new Map<number, Coin>();
 	const TX_FEES = new Map<number, StdFee>();
 	const PROFIT_THRESHOLDS = new Map<number, number>();
-	for (let hops = 2; hops <= MAX_PATH_HOPS; hops++) {
+	for (let hops = 2; hops <= (MAX_PATH_HOPS - 1) * 2 + 1; hops++) {
 		const gasFee = { denom: envs.BASE_DENOM, amount: String(GAS_USAGE_PER_HOP * hops * +GAS_UNIT_PRICE) };
-		GAS_FEES.set(hops, gasFee);
 		TX_FEES.set(hops, { amount: [gasFee], gas: String(GAS_USAGE_PER_HOP * hops) });
-		const profitThreshold: number =
-			skipConfig === undefined
-				? PROFIT_THRESHOLD / (1 - FLASHLOAN_FEE / 100) + +gasFee.amount //dont use skip bid on top of the threshold, include flashloan fee and gas fee
-				: PROFIT_THRESHOLD / (1 - FLASHLOAN_FEE / 100) +
-				  +gasFee.amount +
-				  skipConfig.skipBidRate * PROFIT_THRESHOLD; //need extra profit to provide the skip bid
+		const profitThreshold: number = PROFIT_THRESHOLD + +gasFee.amount;
 		PROFIT_THRESHOLDS.set(hops, profitThreshold);
 	}
 	const botConfig: BotConfig = {
@@ -90,6 +83,7 @@ export function setBotConfig(envs: NodeJS.ProcessEnv): BotConfig {
 		maxPathPools: MAX_PATH_HOPS,
 		mappingFactoryRouter: FACTORIES_TO_ROUTERS_MAPPING,
 		flashloanRouterAddress: envs.FLASHLOAN_ROUTER_ADDRESS,
+		flashloanFee: +envs.FLASHLOAN_FEE,
 		offerAssetInfo: OFFER_ASSET_INFO,
 		mnemonic: envs.WALLET_MNEMONIC,
 		useMempool: envs.USE_MEMPOOL == "1" ? true : false,

--- a/src/core/types/base/path.ts
+++ b/src/core/types/base/path.ts
@@ -2,4 +2,5 @@ import { Pool } from "./pool";
 
 export interface Path {
 	pools: Array<Pool>;
+	cooldown: boolean;
 }

--- a/src/core/types/base/pool.ts
+++ b/src/core/types/base/pool.ts
@@ -99,108 +99,117 @@ export function applyMempoolTradesOnPools(pools: Array<Pool>, mempoolTrades: Arr
 			undefined,
 	);
 	for (const trade of filteredTrades) {
-		const poolToUpdate = pools.find((pool) => trade.contract === pool.address);
-		const msg = trade.message;
-		if (poolToUpdate) {
-			// a direct swap or send to pool
-			if (isSwapMessage(msg) && trade.offer_asset !== undefined) {
-				applyTradeOnPool(poolToUpdate, trade.offer_asset);
-			} else if (isSendMessage(msg) && trade.offer_asset !== undefined) {
-				applyTradeOnPool(poolToUpdate, trade.offer_asset);
-			} else if (isJunoSwapMessage(msg) && trade.offer_asset === undefined) {
-				// For JunoSwap messages we dont have an offerAsset provided in the message
-				const offerAsset: Asset = {
-					amount: msg.swap.input_amount,
-					info: msg.swap.input_token === "Token1" ? poolToUpdate.assets[0].info : poolToUpdate.assets[1].info,
-				};
-				applyTradeOnPool(poolToUpdate, offerAsset);
-			} else if (isJunoSwapOperationsMessage(msg) && trade.offer_asset === undefined) {
-				// JunoSwap operations router message
-				// For JunoSwap messages we dont have an offerAsset provided in the message
-				const offerAsset: Asset = {
-					amount: msg.pass_through_swap.input_token_amount,
-					info:
-						msg.pass_through_swap.input_token === "Token1"
-							? poolToUpdate.assets[0].info
-							: poolToUpdate.assets[1].info,
-				};
-				applyTradeOnPool(poolToUpdate, offerAsset);
+		try {
+			const poolToUpdate = pools.find((pool) => trade.contract === pool.address);
+			const msg = trade.message;
+			if (poolToUpdate) {
+				// a direct swap or send to pool
+				if (isSwapMessage(msg) && trade.offer_asset !== undefined) {
+					applyTradeOnPool(poolToUpdate, trade.offer_asset);
+				} else if (isSendMessage(msg) && trade.offer_asset !== undefined) {
+					applyTradeOnPool(poolToUpdate, trade.offer_asset);
+				} else if (isJunoSwapMessage(msg) && trade.offer_asset === undefined) {
+					// For JunoSwap messages we dont have an offerAsset provided in the message
+					const offerAsset: Asset = {
+						amount: msg.swap.input_amount,
+						info:
+							msg.swap.input_token === "Token1"
+								? poolToUpdate.assets[0].info
+								: poolToUpdate.assets[1].info,
+					};
+					applyTradeOnPool(poolToUpdate, offerAsset);
+				} else if (isJunoSwapOperationsMessage(msg) && trade.offer_asset === undefined) {
+					// JunoSwap operations router message
+					// For JunoSwap messages we dont have an offerAsset provided in the message
+					const offerAsset: Asset = {
+						amount: msg.pass_through_swap.input_token_amount,
+						info:
+							msg.pass_through_swap.input_token === "Token1"
+								? poolToUpdate.assets[0].info
+								: poolToUpdate.assets[1].info,
+					};
+					applyTradeOnPool(poolToUpdate, offerAsset);
 
-				// Second swap
-				const [outGivenIn0, nextOfferAssetInfo] = outGivenIn(poolToUpdate, offerAsset);
-				const secondPoolToUpdate = pools.find(
-					(pool) => pool.address === msg.pass_through_swap.output_amm_address,
-				);
+					// Second swap
+					const [outGivenIn0, nextOfferAssetInfo] = outGivenIn(poolToUpdate, offerAsset);
+					const secondPoolToUpdate = pools.find(
+						(pool) => pool.address === msg.pass_through_swap.output_amm_address,
+					);
 
-				if (secondPoolToUpdate !== undefined) {
-					applyTradeOnPool(secondPoolToUpdate, { amount: String(outGivenIn0), info: nextOfferAssetInfo });
-				}
-			} else if (isTFMSwapOperationsMessage(msg) && trade.offer_asset !== undefined) {
-				let offerAsset: Asset = trade.offer_asset;
-				for (const operation of msg.execute_swap_operations.routes[0].operations) {
-					const currentPool = pools.find((pool) => pool.address === operation.t_f_m_swap.pair_contract);
-					if (currentPool) {
-						const [outGivenInNext, offerAssetInfoNext] = outGivenIn(currentPool, offerAsset);
-						applyTradeOnPool(currentPool, offerAsset);
-						offerAsset = { amount: String(outGivenInNext), info: offerAssetInfoNext };
+					if (secondPoolToUpdate !== undefined) {
+						applyTradeOnPool(secondPoolToUpdate, { amount: String(outGivenIn0), info: nextOfferAssetInfo });
 					}
-				}
-			}
-		}
-		// not a direct swap or swaps on pools, but a routed message using a Router contract
-		else if (isSwapOperationsMessage(msg) && trade.offer_asset !== undefined) {
-			const poolsFromThisRouter = pools.filter((pool) => trade.contract === pool.routerAddress);
-			if (poolsFromThisRouter) {
-				let offerAsset: Asset = trade.offer_asset;
-				const operations = msg.execute_swap_operations.operations;
-				if (isWWSwapOperationsMessages(operations)) {
-					// terraswap router
-					for (const operation of operations) {
-						const currentPool = findPoolByInfos(
-							poolsFromThisRouter,
-							operation.terra_swap.offer_asset_info,
-							operation.terra_swap.ask_asset_info,
-						);
-
-						if (currentPool !== undefined) {
-							applyTradeOnPool(currentPool, offerAsset);
+				} else if (isTFMSwapOperationsMessage(msg) && trade.offer_asset !== undefined) {
+					let offerAsset: Asset = trade.offer_asset;
+					for (const operation of msg.execute_swap_operations.routes[0].operations) {
+						const currentPool = pools.find((pool) => pool.address === operation.t_f_m_swap.pair_contract);
+						if (currentPool) {
 							const [outGivenInNext, offerAssetInfoNext] = outGivenIn(currentPool, offerAsset);
-							offerAsset = { amount: String(outGivenInNext), info: offerAssetInfoNext };
-						}
-					}
-				}
-				if (isAstroSwapOperationsMessages(operations)) {
-					// astropoart router
-					for (const operation of operations) {
-						const currentPool = findPoolByInfos(
-							poolsFromThisRouter,
-							operation.astro_swap.offer_asset_info,
-							operation.astro_swap.ask_asset_info,
-						);
-						if (currentPool !== undefined) {
 							applyTradeOnPool(currentPool, offerAsset);
-							const [outGivenInNext, offerAssetInfoNext] = outGivenIn(currentPool, offerAsset);
-							offerAsset = { amount: String(outGivenInNext), info: offerAssetInfoNext };
-						}
-					}
-				}
-				if (isWyndDaoSwapOperationsMessages(operations)) {
-					for (const operation of operations) {
-						const offerAssetInfo = isWyndDaoNativeAsset(operation.wyndex_swap.offer_asset_info)
-							? { native_token: { denom: operation.wyndex_swap.offer_asset_info.native } }
-							: { token: { contract_addr: operation.wyndex_swap.offer_asset_info.token } };
-						const askAssetInfo = isWyndDaoNativeAsset(operation.wyndex_swap.ask_asset_info)
-							? { native_token: { denom: operation.wyndex_swap.ask_asset_info.native } }
-							: { token: { contract_addr: operation.wyndex_swap.ask_asset_info.token } };
-						const currentPool = findPoolByInfos(poolsFromThisRouter, offerAssetInfo, askAssetInfo);
-						if (currentPool !== undefined) {
-							applyTradeOnPool(currentPool, offerAsset);
-							const [outGivenInNext, offerAssetInfoNext] = outGivenIn(currentPool, offerAsset);
 							offerAsset = { amount: String(outGivenInNext), info: offerAssetInfoNext };
 						}
 					}
 				}
 			}
+			// not a direct swap or swaps on pools, but a routed message using a Router contract
+			else if (isSwapOperationsMessage(msg) && trade.offer_asset !== undefined) {
+				const poolsFromThisRouter = pools.filter((pool) => trade.contract === pool.routerAddress);
+				if (poolsFromThisRouter) {
+					let offerAsset: Asset = trade.offer_asset;
+					const operations = msg.execute_swap_operations.operations;
+					if (isWWSwapOperationsMessages(operations)) {
+						// terraswap router
+						for (const operation of operations) {
+							const currentPool = findPoolByInfos(
+								poolsFromThisRouter,
+								operation.terra_swap.offer_asset_info,
+								operation.terra_swap.ask_asset_info,
+							);
+
+							if (currentPool !== undefined) {
+								applyTradeOnPool(currentPool, offerAsset);
+								const [outGivenInNext, offerAssetInfoNext] = outGivenIn(currentPool, offerAsset);
+								offerAsset = { amount: String(outGivenInNext), info: offerAssetInfoNext };
+							}
+						}
+					}
+					if (isAstroSwapOperationsMessages(operations)) {
+						// astropoart router
+						for (const operation of operations) {
+							const currentPool = findPoolByInfos(
+								poolsFromThisRouter,
+								operation.astro_swap.offer_asset_info,
+								operation.astro_swap.ask_asset_info,
+							);
+							if (currentPool !== undefined) {
+								applyTradeOnPool(currentPool, offerAsset);
+								const [outGivenInNext, offerAssetInfoNext] = outGivenIn(currentPool, offerAsset);
+								offerAsset = { amount: String(outGivenInNext), info: offerAssetInfoNext };
+							}
+						}
+					}
+					if (isWyndDaoSwapOperationsMessages(operations)) {
+						for (const operation of operations) {
+							const offerAssetInfo = isWyndDaoNativeAsset(operation.wyndex_swap.offer_asset_info)
+								? { native_token: { denom: operation.wyndex_swap.offer_asset_info.native } }
+								: { token: { contract_addr: operation.wyndex_swap.offer_asset_info.token } };
+							const askAssetInfo = isWyndDaoNativeAsset(operation.wyndex_swap.ask_asset_info)
+								? { native_token: { denom: operation.wyndex_swap.ask_asset_info.native } }
+								: { token: { contract_addr: operation.wyndex_swap.ask_asset_info.token } };
+							const currentPool = findPoolByInfos(poolsFromThisRouter, offerAssetInfo, askAssetInfo);
+							if (currentPool !== undefined) {
+								applyTradeOnPool(currentPool, offerAsset);
+								const [outGivenInNext, offerAssetInfoNext] = outGivenIn(currentPool, offerAsset);
+								offerAsset = { amount: String(outGivenInNext), info: offerAssetInfoNext };
+							}
+						}
+					}
+				}
+			}
+		} catch (e) {
+			console.log("cannot apply trade on pools:");
+			console.log(trade);
+			console.log(e);
 		}
 	}
 }
@@ -225,6 +234,8 @@ export function getAssetsOrder(pool: Pool, assetInfo: AssetInfo) {
 		return [pool.assets[0], pool.assets[1]] as Array<Asset>;
 	} else if (isMatchingAssetInfos(pool.assets[1].info, assetInfo)) {
 		return [pool.assets[1], pool.assets[0]] as Array<Asset>;
+	} else {
+		return undefined;
 	}
 }
 


### PR DESCRIPTION
* feat: add cooldown feature to paths, calculate fees based on msgs

We use a cooldown feature on paths to prevent the bot for overtrading a path whiles the arb is already gone. if it did one attempt cooldown is set to true, on next block arrival the bot sets all paths cooldowns back to false.
Also, this commit changes the way fees are attached to TXs, because fees do not only scale with amount of pools, but also amount of messages used for a pooltrade, therefore the amount of msgs is used as an indexer for the amount of txfees to attach to a tx

* bug: fix profit calculation based on tradesize and skipbid

* chore: more comments on profit calc and try-catch on mempool tx

## Description and Motivation

<!-- 
    
    Please write a description of what this PR is changing, removing or adding, and why. Consider including before/after 
    comparisons.

-->

## Related Issues

<!-- 
    
    Add the list of issues related to this PR from the [issue tracker](https://github.com/White-Whale-Defi-Platform/migaloo-bots/issues).
    Indicate, which of these issues are resolved or fixed by this PR, like #XXXX, where XXXX is the issue number.

-->


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [ ] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [ ] My pull request has a sound title and description (not something vague like `Update index.md`)
- [ ] All existing and new tests are passing (if any).
- [ ] I updated/added relevant documentation.
- [ ] The code is formatted properly using eslint
