### PR TITLE
Dynamic skip rate DRAFT

### DIFF
--- a/.env.juno.example
+++ b/.env.juno.example
@@ -19,7 +19,7 @@ SKIP_URL= "http://juno-1-api.skip.money"
 SKIP_BID_WALLET= "juno10g0l3hd9sau3vnjrayjhergcpxemucxcspgnn4"
 MAX_SKIP_BID_RATE="0.52" #e.g. 20% of the profit is used as a bid to win the auction
 MIN_SKIP_BID_RATE="0.2" #e.g. 20% of the profit is used as a bid to win the auction
-BIDDING_STEPS="0.02"
+
 
 ## CHAIN SPECIFIC SETTINGS
 BASE_DENOM="ujuno" # The asset denom to be used as base asset. This should be the denom of a Native Token only.

--- a/.env.juno.example
+++ b/.env.juno.example
@@ -15,7 +15,9 @@ MAX_PATH_HOPS="4"
 USE_SKIP = "1"
 SKIP_URL= "http://juno-1-api.skip.money"
 SKIP_BID_WALLET= "juno10g0l3hd9sau3vnjrayjhergcpxemucxcspgnn4"
-SKIP_BID_RATE="0.31" #e.g. 20% of the profit is used as a bid to win the auction
+MAX_SKIP_BID_RATE="0.52" #e.g. 20% of the profit is used as a bid to win the auction
+MIN_SKIP_BID_RATE="0.2" #e.g. 20% of the profit is used as a bid to win the auction
+BIDDING_STEPS="0.02"
 
 ## CHAIN SPECIFIC SETTINGS
 BASE_DENOM="ujuno" # The asset denom to be used as base asset. This should be the denom of a Native Token only.

--- a/src/core/types/arbitrageloops/skipLoop.ts
+++ b/src/core/types/arbitrageloops/skipLoop.ts
@@ -139,7 +139,9 @@ export class SkipLoop extends MempoolLoop {
 		let res: SkipResult | undefined;
 		let bid_raw: TxRaw;
 		const txToArbRaw: TxRaw = TxRaw.decode(toArbTrade.txBytes);
-		let curr_bid = this.botConfig.skipConfig.min_skip_bid_rate - this.botConfig.skipConfig.bidding_steps;
+		const bidding_steps: number =
+			(this.botConfig.skipConfig.max_skip_bid_rate - this.botConfig.skipConfig.min_skip_bid_rate) / 5;
+		let curr_bid = this.botConfig.skipConfig.min_skip_bid_rate - bidding_steps;
 		let signed;
 
 		// Loop until the skip respond code ist not 7 = The bundle was not simulated -- usually this means it lost the auction or arrived too late
@@ -147,9 +149,9 @@ export class SkipLoop extends MempoolLoop {
 
 		while (
 			(!res || !res.result.code || res.result.code == 7) &&
-			curr_bid + this.botConfig.skipConfig.bidding_steps <= this.botConfig.skipConfig.max_skip_bid_rate
+			curr_bid + bidding_steps <= this.botConfig.skipConfig.max_skip_bid_rate
 		) {
-			curr_bid = curr_bid + this.botConfig.skipConfig.bidding_steps;
+			curr_bid = curr_bid + bidding_steps;
 			bid_raw = await this.createBidMsg(
 				arbTrade,
 				curr_bid,

--- a/src/core/types/arbitrageloops/skipLoop.ts
+++ b/src/core/types/arbitrageloops/skipLoop.ts
@@ -133,29 +133,15 @@ export class SkipLoop extends MempoolLoop {
 		// const txBytes = TxRaw.encode(txRaw).finish();
 		// const normalResult = await this.botClients.TMClient.broadcastTxSync({ tx: txBytes });
 		// console.log(normalResult);
-		let res: SkipResult = {
-			result: {
-				code: 7,
-				txs: [],
-				auction_fee: "",
-				bundle_size: "",
-				desired_height: "",
-				waited_for_simulation_results: true,
-				simulation_success: true,
-				result_check_txs: [],
-				result_deliver_txs: [],
-				error: "",
-			},
-			jsonrpc: "",
-			id: 0,
-		};
+		// eslint-disable-next-line no-undef-init
+		let res: SkipResult | undefined;
 		let bid_raw: TxRaw;
 		const txToArbRaw: TxRaw = TxRaw.decode(toArbTrade.txBytes);
 		let curr_bid = this.botConfig.skipConfig.min_skip_bid_rate - this.botConfig.skipConfig.bidding_steps;
 		let signed;
 
 		while (
-			(!res.result.code || res.result.code == 7) &&
+			(!res || !res.result.code || res.result.code == 7) &&
 			curr_bid + this.botConfig.skipConfig.bidding_steps <= this.botConfig.skipConfig.max_skip_bid_rate
 		) {
 			curr_bid = curr_bid + this.botConfig.skipConfig.bidding_steps;

--- a/src/core/types/arbitrageloops/skipLoop.ts
+++ b/src/core/types/arbitrageloops/skipLoop.ts
@@ -98,6 +98,7 @@ export class SkipLoop extends MempoolLoop {
 			!this.botConfig.skipConfig?.useSkip ||
 			this.botConfig.skipConfig?.skipRpcUrl === undefined ||
 			this.botConfig.skipConfig?.min_skip_bid_rate === undefined ||
+			this.botConfig.skipConfig?.max_skip_bid_rate === undefined ||
 			this.botConfig.skipConfig?.skipBidWallet === undefined
 		) {
 			await this.logger?.sendMessage(

--- a/src/core/types/base/botConfig.ts
+++ b/src/core/types/base/botConfig.ts
@@ -9,7 +9,6 @@ interface SkipConfig {
 	skipBidWallet: string;
 	min_skip_bid_rate: number;
 	max_skip_bid_rate: number;
-	bidding_steps:number;
 }
 export interface BotConfig {
 	chainPrefix: string;
@@ -76,7 +75,6 @@ export function setBotConfig(envs: NodeJS.ProcessEnv): BotConfig {
 			skipBidWallet: envs.SKIP_BID_WALLET ?? "",
 			min_skip_bid_rate: envs.MIN_SKIP_BID_RATE === undefined ? 0 : +envs.MIN_SKIP_BID_RATE,
 			max_skip_bid_rate: envs.MAX_SKIP_BID_RATE === undefined ? 0 : +envs.MAX_SKIP_BID_RATE,
-			bidding_steps: envs.BIDDING_STEPS === undefined ? 0 : +envs.BIDDING_STEPS,
 		};
 	}
 	const PROFIT_THRESHOLD = +envs.PROFIT_THRESHOLD;

--- a/src/core/types/base/botConfig.ts
+++ b/src/core/types/base/botConfig.ts
@@ -134,5 +134,4 @@ function validateSkipEnvs(envs: NodeJS.ProcessEnv) {
 	assert(envs.SKIP_BID_WALLET, `Please set SKIP_BID_WALLET in env or ".env" file`);
 	assert(envs.MAX_SKIP_BID_RATE, `Please set MAX_SKIP_BID_RATE in env or ".env" file`);
 	assert(envs.MIN_SKIP_BID_RATE, `Please set MIN_SKIP_BID_RATE in env or ".env" file`);
-	assert(envs.BIDDING_STEPS, `Please set BIDDING_STEPS in env or ".env" file`);
 }

--- a/src/core/types/base/botConfig.ts
+++ b/src/core/types/base/botConfig.ts
@@ -7,7 +7,9 @@ interface SkipConfig {
 	useSkip: boolean;
 	skipRpcUrl: string;
 	skipBidWallet: string;
-	skipBidRate: number;
+	min_skip_bid_rate: number;
+	max_skip_bid_rate: number;
+	bidding_steps:number;
 }
 export interface BotConfig {
 	chainPrefix: string;
@@ -70,7 +72,9 @@ export function setBotConfig(envs: NodeJS.ProcessEnv): BotConfig {
 			useSkip: true,
 			skipRpcUrl: envs.SKIP_URL ?? "",
 			skipBidWallet: envs.SKIP_BID_WALLET ?? "",
-			skipBidRate: envs.SKIP_BID_RATE === undefined ? 0 : +envs.SKIP_BID_RATE,
+			min_skip_bid_rate: envs.MIN_SKIP_BID_RATE === undefined ? 0 : +envs.MIN_SKIP_BID_RATE,
+			max_skip_bid_rate: envs.MAX_SKIP_BID_RATE === undefined ? 0 : +envs.MAX_SKIP_BID_RATE,
+			bidding_steps: envs.BIDDING_STEPS === undefined ? 0 : +envs.BIDDING_STEPS,
 		};
 	}
 	const PROFIT_THRESHOLD = +envs.PROFIT_THRESHOLD;
@@ -127,5 +131,7 @@ function validateEnvs(envs: NodeJS.ProcessEnv) {
 function validateSkipEnvs(envs: NodeJS.ProcessEnv) {
 	assert(envs.SKIP_URL, `Please set SKIP_URL in env or ".env" file`);
 	assert(envs.SKIP_BID_WALLET, `Please set SKIP_BID_WALLET in env or ".env" file`);
-	assert(envs.SKIP_BID_RATE, `Please set SKIP_BID_RATE in env or ".env" file`);
+	assert(envs.MAX_SKIP_BID_RATE, `Please set MAX_SKIP_BID_RATE in env or ".env" file`);
+	assert(envs.MIN_SKIP_BID_RATE, `Please set MIN_SKIP_BID_RATE in env or ".env" file`);
+	assert(envs.BIDDING_STEPS, `Please set BIDDING_STEPS in env or ".env" file`);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,6 @@ async function main() {
 	const chainId = await (
 		await botClients.HttpClient.execute(createJsonRpcRequest("block"))
 	).result.block.header.chain_id;
-
 	let setupMessage = `
 Connections Details:\n
 **Account Number:** ${accountNumber}


### PR DESCRIPTION
## Description and Motivation
I would like to put this implementation up for discussion.

This adds a dynamic skip bidrate fixed to 5 bids per trade attempt.
You can add a min and max skip %; starts with the lowest and will climb in 5 tries to the max.
The goal is to send the message in the next block. 

I really appreciate your feedback.



## Related Issues


#31 

---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [ ] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
