### PR TITLE
Set to object & shuffled RPCs from registry

### DIFF
--- a/src/core/types/arbitrageloops/mempoolLoop.ts
+++ b/src/core/types/arbitrageloops/mempoolLoop.ts
@@ -17,7 +17,6 @@ export class MempoolLoop {
 	pathlib: Array<Path>; //holds all known paths
 	CDpaths: Map<string, [number, number, number]>; //holds all cooldowned paths' identifiers
 	chainOperator: ChainOperator;
-	// TODO: Change ignore Addresses to opject
 	ignoreAddresses: { [index: string]: boolean };
 	botConfig: BotConfig;
 	logger: Logger | undefined;

--- a/src/core/types/arbitrageloops/mempoolLoop.ts
+++ b/src/core/types/arbitrageloops/mempoolLoop.ts
@@ -18,7 +18,7 @@ export class MempoolLoop {
 	CDpaths: Map<string, [number, number, number]>; //holds all cooldowned paths' identifiers
 	chainOperator: ChainOperator;
 	// TODO: Change ignore Addresses to opject
-	ignoreAddresses: Set<string>;
+	ignoreAddresses: { [index: string]: boolean };
 	botConfig: BotConfig;
 	logger: Logger | undefined;
 	// CACHE VALUES
@@ -54,7 +54,7 @@ export class MempoolLoop {
 		botConfig: BotConfig,
 		logger: Logger | undefined,
 		pathlib: Array<Path>,
-		ignoreAddresses: Set<string>,
+		ignoreAddresses: { [index: string]: boolean },
 	) {
 		this.pools = pools;
 		this.CDpaths = new Map<string, [number, number, number]>();
@@ -102,8 +102,8 @@ export class MempoolLoop {
 			);
 			// Checks if there is a SendMsg from a blacklisted Address, if so add the reciever to the timeouted addresses
 			mempooltxs[1].forEach((Element) => {
-				if (this.ignoreAddresses.has(Element.sender)) {
-					this.ignoreAddresses.add(Element.reciever);
+				if (this.ignoreAddresses[Element.sender]) {
+					this.ignoreAddresses[Element.reciever] = true;
 				}
 			});
 			const mempoolTrades: Array<MempoolTrade> = mempooltxs[0];
@@ -111,7 +111,7 @@ export class MempoolLoop {
 				continue;
 			} else {
 				for (const trade of mempoolTrades) {
-					if (trade.sender && !this.ignoreAddresses.has(trade.sender)) {
+					if (trade.sender && !this.ignoreAddresses[trade.sender]) {
 						applyMempoolTradesOnPools(this.pools, [trade]);
 					}
 				}

--- a/src/core/types/arbitrageloops/skipLoop.ts
+++ b/src/core/types/arbitrageloops/skipLoop.ts
@@ -45,7 +45,7 @@ export class SkipLoop extends MempoolLoop {
 		logger: Logger | undefined,
 
 		pathlib: Array<Path>,
-		ignoreAddresses: Set<string>,
+		ignoreAddresses: { [index: string]: boolean },
 	) {
 		super(
 			pools,
@@ -93,8 +93,8 @@ export class SkipLoop extends MempoolLoop {
 			);
 			const mempoolTrades = mempooltxs[0];
 			mempooltxs[1].forEach((Element) => {
-				if (this.ignoreAddresses.has(Element.sender)) {
-					this.ignoreAddresses.add(Element.reciever);
+				if (this.ignoreAddresses[Element.sender]) {
+					this.ignoreAddresses[Element.reciever] = true;
 				}
 			});
 
@@ -102,7 +102,7 @@ export class SkipLoop extends MempoolLoop {
 				continue;
 			} else {
 				for (const trade of mempoolTrades) {
-					if (trade.sender && !this.ignoreAddresses.has(trade.sender)) {
+					if (trade.sender && !this.ignoreAddresses[trade.sender]) {
 						applyMempoolTradesOnPools(this.pools, [trade]);
 						const arbTrade: OptimalTrade | undefined = this.arbitrageFunction(this.paths, this.botConfig);
 						if (arbTrade) {
@@ -174,7 +174,7 @@ export class SkipLoop extends MempoolLoop {
 					const logMessageCheckTx = `**CheckTx Error:** index: ${idx}\t ${String(item.log)}\n`;
 					logMessage = logMessage.concat(logMessageCheckTx);
 					if (toArbTrade?.sender && idx == 0 && item["code"] == "5") {
-						this.ignoreAddresses.add(toArbTrade.sender);
+						this.ignoreAddresses[toArbTrade.sender] = true;
 						await this.logger?.sendMessage(
 							"Error on Trade from Address: " + toArbTrade.sender,
 							LogType.Console,
@@ -192,7 +192,7 @@ export class SkipLoop extends MempoolLoop {
 					logMessage = logMessage.concat(logMessageDeliverTx);
 					if (idx == 0 && (item["code"] == 10 || item["code"] == 5)) {
 						if (toArbTrade?.sender) {
-							this.ignoreAddresses.add(toArbTrade.sender);
+							this.ignoreAddresses[toArbTrade.sender] = true;
 							await this.logger?.sendMessage(
 								"Error on Trade from Address: " + toArbTrade.sender,
 								LogType.Console,

--- a/src/core/types/base/botConfig.ts
+++ b/src/core/types/base/botConfig.ts
@@ -184,6 +184,26 @@ function validateSkipEnvs(envs: NodeJS.ProcessEnv) {
 /**
  *
  */
+function randomize(values: Array<string>) {
+	let index = values.length,
+		randomIndex;
+
+	// While there remain elements to shuffle.
+	while (index != 0) {
+		// Pick a remaining element.
+		randomIndex = Math.floor(Math.random() * index);
+		index--;
+
+		// And swap it with the current element.
+		[values[index], values[randomIndex]] = [values[randomIndex], values[index]];
+	}
+
+	return values;
+}
+
+/**
+ *
+ */
 async function getRPCfromRegistry(prefix: string, inputurls?: Array<string>) {
 	const registry = await axios.get(`https://api.github.com/repos/cosmos/chain-registry/contents/`);
 	let path = "";
@@ -195,7 +215,7 @@ async function getRPCfromRegistry(prefix: string, inputurls?: Array<string>) {
 	const chaindata = await axios.get(
 		`https://raw.githubusercontent.com/cosmos/chain-registry/master/${path}/chain.json`,
 	);
-	const rpcs = chaindata.data.apis.rpc;
+	const rpcs = randomize(chaindata.data.apis.rpc);
 	let out: Array<string>;
 	if (!inputurls) {
 		out = new Array<string>();

--- a/src/core/types/base/botConfig.ts
+++ b/src/core/types/base/botConfig.ts
@@ -25,7 +25,7 @@ export interface BotConfig {
 	chainPrefix: string;
 	rpcUrls: Array<string>;
 	useRpcUrlScraper: boolean;
-	ignoreAddresses: Set<string>;
+	ignoreAddresses: { [index: string]: boolean };
 	poolEnvs: Array<{ pool: string; inputfee: number; outputfee: number; LPratio: number }>;
 	maxPathPools: number;
 	mappingFactoryRouter: Array<{ factory: string; router: string }>;
@@ -85,11 +85,11 @@ export async function setBotConfig(envs: NodeJS.ProcessEnv): Promise<BotConfig> 
 	const GAS_USAGE_PER_HOP = +envs.GAS_USAGE_PER_HOP;
 	const MAX_PATH_HOPS = +envs.MAX_PATH_HOPS; //required gas units per trade (hop)
 
-	const IGNORE_ADDRS = new Set<string>();
+	const IGNORE_ADDRS: { [index: string]: boolean } = {};
 	// set ignored Addresses
 	if (envs.IGNORE_ADDRESSES) {
 		const addrs = JSON.parse(envs.IGNORE_ADDRESSES);
-		addrs.forEach((element: string) => IGNORE_ADDRS.add(element));
+		addrs.forEach((element: string) => (IGNORE_ADDRS[element] = true));
 	}
 	// setup skipconfig if present
 	let skipConfig;

--- a/src/core/types/base/mempool.ts
+++ b/src/core/types/base/mempool.ts
@@ -64,7 +64,7 @@ export function showTxMemory() {
  */
 export function processMempool(
 	mempool: Mempool,
-	ignoreAddresses: Set<string>,
+	ignoreAddresses: { [index: string]: boolean },
 ): [Array<MempoolTrade>, Array<{ sender: string; reciever: string }>] {
 	const mempoolTrades: [Array<MempoolTrade>, Array<{ sender: string; reciever: string }>] = [[], []];
 	for (const tx of mempool.txs) {
@@ -185,7 +185,7 @@ export function processMempool(
 					if (mempoolTrade) {
 						mempoolTrades[0].push(mempoolTrade);
 					}
-				} else if (ignoreAddresses.has(msgExecuteContract.contract)) {
+				} else if (ignoreAddresses[msgExecuteContract.contract]) {
 					const gets = fromAscii(fromBase64(containedMsg.delegate.msg));
 					mempoolTrades[1].push({ sender: msgExecuteContract.contract, reciever: gets });
 				} else {


### PR DESCRIPTION
## Description and Motivation

Changes the Ignored Addresses to an object for faster access, shuffle queried RPCs to prevent Errors on startup.
The given RPC(s) are used before the queried ones and are not shuffled.

## Related Issues

#77


---
## Checklist:

<!-- 

    Thanks for contributing to White Whale Migaloo! 
    
    Before you file this pull request, please follow the items on this checklist and put an x in each of the boxes, 
    like this: [x]. 
    
    Make sure to follow the guidelines, so we can process this PR as fast as possible. 

-->

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [ ] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
