### PR TITLE
fix: Use unless-stopped for docker containers to prevent unexpected starts after docker daemon reboot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     container_name: white-whale-bot
     env_file:
       - .env
-    restart: always
+    restart: unless-stopped
     stdin_open: true
     tty: true
     

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,5 +9,4 @@ services:
       - .env
     restart: unless-stopped
     stdin_open: true
-    tty: true
-    
+    tty: true    


### PR DESCRIPTION
## Description and Motivation

Has all bots restarted after a server reboot, also the one I've stopped manually.

unless-stopped is similar to always, except that when the container is stopped (manually or otherwise), it is not restarted even after Docker daemon restarts.

- https://dev.to/rohithv07/restart-policies-docker-compose-2c14
- https://docs.docker.com/config/containers/start-containers-automatically/

## Related Issues

n/a 

## Checklist:

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
