### PR TITLE
bug: fix injective rounding issue when using String()

### DIFF
--- a/src/core/types/base/asset.ts
+++ b/src/core/types/base/asset.ts
@@ -2,6 +2,11 @@ import BigNumber from "bignumber.js";
 
 import { Uint128 } from "./uint128";
 
+BigNumber.config({
+	ROUNDING_MODE: BigNumber.ROUND_DOWN,
+	EXPONENTIAL_AT: [-10, 20],
+});
+
 export interface Asset {
 	amount: Uint128;
 	info: AssetInfo;
@@ -82,7 +87,7 @@ export function isMatchingAssetInfos(a: AssetInfo, b: AssetInfo) {
 export function toChainAsset(input: Asset): Asset {
 	if (isNativeAsset(input.info) && input.info.native_token.denom === "inj") {
 		return {
-			amount: String(new BigNumber(+input.amount).multipliedBy(new BigNumber(10).pow(12))),
+			amount: new BigNumber(+input.amount).multipliedBy(new BigNumber(10).pow(12)).toFixed(),
 			info: input.info,
 		};
 	} else
@@ -98,7 +103,7 @@ export function toChainAsset(input: Asset): Asset {
 export function fromChainAsset(input: Asset): Asset {
 	if (isNativeAsset(input.info) && input.info.native_token.denom === "inj") {
 		return {
-			amount: String(new BigNumber(+input.amount).dividedBy(new BigNumber(10).pow(12))),
+			amount: new BigNumber(+input.amount).dividedBy(new BigNumber(10).pow(12)).toFixed(6),
 			info: input.info,
 		};
 	} else return input;

--- a/src/tests/core/types/base/asset.spec.ts
+++ b/src/tests/core/types/base/asset.spec.ts
@@ -10,14 +10,13 @@ dotenv.config();
 describe("Test convert 18 to 6 decimal asset and vice versa", () => {
 	it("Should return 6 decimal asset after 18 decimal input 'inj' denom converting FROM chain", async () => {
 		const input: Asset = {
-			amount: String(new BigNumber(5).multipliedBy(new BigNumber(10).pow(18))),
+			amount: String(new BigNumber("512.1234123445245667543").multipliedBy(new BigNumber(10).pow(18))),
 			info: { native_token: { denom: "inj" } },
 		};
 
 		const output = fromChainAsset(input);
-
 		const times = +input.amount / +output.amount;
-		assert.equal(times, 1e12);
+		assert.equal(Math.floor(times), 1e12);
 	});
 
 	it("Should return 6 decimal asset after 6 decimal input non 'inj' denom FROM chain", async () => {
@@ -33,7 +32,7 @@ describe("Test convert 18 to 6 decimal asset and vice versa", () => {
 
 	it("Should return 18 decimal asset after 6 decimal input 'inj' denom TO chain", async () => {
 		const input: Asset = {
-			amount: String(new BigNumber("5.1234123412341234123412341324").multipliedBy(new BigNumber(10).pow(6))),
+			amount: String(new BigNumber("512.34123412341234123412341324").multipliedBy(new BigNumber(10).pow(6))),
 			info: { native_token: { denom: "inj" } },
 		};
 


### PR DESCRIPTION
The String() method caused non fixed numerical values to appear in trading messages (like 1224.2345e+20). this is incorrect behaviour and is solved by using the .toFixed() method from the BigNumber package. 

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
