### PR TITLE
Feat/remove adapter reset on newblock

### DIFF
--- a/src/core/types/arbitrageloops/mempoolLoop.ts
+++ b/src/core/types/arbitrageloops/mempoolLoop.ts
@@ -119,7 +119,7 @@ export class MempoolLoop {
 			if (arbTrade) {
 				await this.trade(arbTrade);
 				this.cdPaths(arbTrade.path);
-
+				await this.chainOperator.reset();
 				break;
 			}
 		}
@@ -134,7 +134,6 @@ export class MempoolLoop {
 		this.unCDPaths();
 		this.totalBytes = 0;
 		flushTxMemory();
-		await this.chainOperator.reset();
 	}
 
 	/**

--- a/src/core/types/arbitrageloops/mempoolLoop.ts
+++ b/src/core/types/arbitrageloops/mempoolLoop.ts
@@ -1,3 +1,5 @@
+import { sha256 } from "@cosmjs/crypto";
+import { toHex } from "@cosmjs/encoding";
 import { EncodeObject } from "@cosmjs/proto-signing";
 
 import { OptimalTrade } from "../../arbitrage/arbitrage";
@@ -118,6 +120,10 @@ export class MempoolLoop {
 
 			if (arbTrade) {
 				await this.trade(arbTrade);
+				console.log("mempool transactions to backrun:");
+				mempoolTrades.map((mpt) => {
+					console.log(toHex(sha256(mpt.txBytes)));
+				});
 				this.cdPaths(arbTrade.path);
 				await this.chainOperator.reset();
 				break;

--- a/src/core/types/arbitrageloops/nomempoolLoop.ts
+++ b/src/core/types/arbitrageloops/nomempoolLoop.ts
@@ -84,6 +84,7 @@ export class NoMempoolLoop {
 			console.log("expected profit: ", arbTrade.profit);
 			await this.trade(arbTrade);
 			this.cdPaths(arbTrade.path);
+			await this.chainOperator.reset();
 		}
 
 		await delay(1500);
@@ -95,7 +96,6 @@ export class NoMempoolLoop {
 	async reset() {
 		this.unCDPaths();
 		await this.updateStateFunction(this.chainOperator, this.pools);
-		await this.chainOperator.reset();
 	}
 
 	/**

--- a/src/core/types/arbitrageloops/skipLoop.ts
+++ b/src/core/types/arbitrageloops/skipLoop.ts
@@ -1,3 +1,5 @@
+import { sha256 } from "@cosmjs/crypto";
+import { toHex } from "@cosmjs/encoding";
 import { DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
 import { EncodeObject } from "@cosmjs/proto-signing";
 import { SkipBundleClient } from "@skip-mev/skipjs";
@@ -105,6 +107,8 @@ export class SkipLoop extends MempoolLoop {
 						applyMempoolTradesOnPools(this.pools, [trade]);
 						const arbTrade: OptimalTrade | undefined = this.arbitrageFunction(this.paths, this.botConfig);
 						if (arbTrade) {
+							console.log("mempool transaction to backrun: ");
+							console.log(toHex(sha256(trade.txBytes)));
 							await this.skipTrade(arbTrade, trade);
 							this.cdPaths(arbTrade.path);
 							return;


### PR DESCRIPTION
## Description and Motivation
This PR makes sure the bot does not query the accountnumber and sequence on each iteration reset. This query is delaying runtime whilst its only needed after the bot actually performed a trade.
Also, a print is added that prints the TXHash of a transaction we try to backrun if there is any. This makes searching for attempts easier in the blockchain if our own arbitrage transaction fails and thus not exists. 

- [x] I have read [Migaloo's contribution guidelines](https://github.com/White-Whale-Defi-Platform/migaloo-bots/blob/main/CONTRIBUTING.md).
- [x] My pull request has a sound title and description (not something vague like `Update index.md`)
- [x] All existing and new tests are passing (if any).
- [x] I updated/added relevant documentation.
- [x] The code is formatted properly using eslint
