### PR TITLE
Upgrade vulnerable dependencies to fixed versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19
+FROM node:20.7
 
 ENV TERM=xterm
 RUN mkdir /usr/src/app

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@cosmjs/stargate": "^0.29.4",
         "@cosmjs/tendermint-rpc": "^0.29.4",
         "@injectivelabs/networks": "^1.0.105",
-        "@injectivelabs/sdk-ts": "^1.0.487",
+        "@injectivelabs/sdk-ts": "^1.12.1",
         "@injectivelabs/ts-types": "^1.0.39",
         "@skip-mev/skipjs": "1.1.0",
         "@slack/web-api": "^6.8.0",
@@ -1603,9 +1603,9 @@
       "dev": true
     },
     "node_modules/@injectivelabs/core-proto-ts": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.14.tgz",
-      "integrity": "sha512-NZWlgBzgVrXow9IknFQHvcYKX4QkUD25taRigoNYQK8PDn4+VXd9xM5WFUDRhzm2smTCguyl/+MghpEp4oTPWw==",
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/core-proto-ts/-/core-proto-ts-0.0.18.tgz",
+      "integrity": "sha512-WSZS7SQ+I/m8jdc7fhzkMTUhA7i5nVTeKbN6QGqKmOwQ/F+PqM75vDHD9Y9NbLPx9P+m7hyUzSHz4zmajth5jw==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -1619,9 +1619,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@injectivelabs/core-proto-ts/node_modules/protobufjs": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
-      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -1681,13 +1681,13 @@
       }
     },
     "node_modules/@injectivelabs/exceptions": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.11.0.tgz",
-      "integrity": "sha512-jZ0N4cP1KCyErNEiCARaKt70E8KMTNa9R4a5FrCERX4cFKPxdbWpoQ8Lqga2jfHAgiFcChRJ5JmaSYclFtKf9w==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/exceptions/-/exceptions-1.14.0.tgz",
+      "integrity": "sha512-mBko+41wfbyhTIFYGACXQXA0KsxolBj9H7DmnWPWqieCaiuUQTYRy/xJ3gaPxDGrkz2tvU9q6if9o2xkEinh3g==",
       "hasInstallScript": true,
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
-        "@injectivelabs/ts-types": "^1.11.0",
+        "@injectivelabs/ts-types": "^1.14.0",
         "http-status-codes": "^2.2.0",
         "link-module-alias": "^1.2.0",
         "shx": "^0.3.2"
@@ -1721,9 +1721,9 @@
       }
     },
     "node_modules/@injectivelabs/indexer-proto-ts": {
-      "version": "1.10.8-rc.4",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.10.8-rc.4.tgz",
-      "integrity": "sha512-IwbepTfsHHAv3Z36As6yH/+HIplOEpUu6SFHBCVgdSIaQ8GuvTib4HETiVnV4mjYqoyVgWs+zLSAfih46rdMJQ==",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.11.9.tgz",
+      "integrity": "sha512-hUlZbSpii+amvqqefH/oV16igRJSx4mCM/Zi0xMZLHyqGkaX7PHVvjQcfX04hwx2MdSsAoDghJXuUrAJ7q9I2A==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -1737,9 +1737,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@injectivelabs/indexer-proto-ts/node_modules/protobufjs": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
-      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -1760,9 +1760,9 @@
       }
     },
     "node_modules/@injectivelabs/mito-proto-ts": {
-      "version": "1.0.17",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.0.17.tgz",
-      "integrity": "sha512-J15hWdcyurGZQ9WslWuzld7A4nBfPsUFBLTHAGNy/MaeU/oJhuMEjEyA9i0KVGn+58bCISOBVh5glxFWqx60wA==",
+      "version": "1.0.43",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/mito-proto-ts/-/mito-proto-ts-1.0.43.tgz",
+      "integrity": "sha512-w2FRECf0KmqhyID6iwKoQj366mSy1URjoWlf3sueM2s4xXee/J2fzYT4JOjt1wK8taLQ/gbIWP8FMTtUvh/+2w==",
       "dependencies": {
         "@injectivelabs/grpc-web": "^0.0.1",
         "google-protobuf": "^3.14.0",
@@ -1776,9 +1776,9 @@
       "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
     },
     "node_modules/@injectivelabs/mito-proto-ts/node_modules/protobufjs": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.3.tgz",
-      "integrity": "sha512-TtpvOqwB5Gdz/PQmOjgsrGH1nHjAQVCN7JG4A6r1sXRWESL5rNMAiRcBQlCAdKxZcAbstExQePYG8xof/JVRgg==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.2.5.tgz",
+      "integrity": "sha512-gGXRSXvxQ7UiPgfw8gevrfRWcTlSbOFg+p/N+JVJEK5VhueL2miT6qTymqAmjr1Q5WbOCyJbyrk6JfWKwlFn6A==",
       "hasInstallScript": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -1799,22 +1799,22 @@
       }
     },
     "node_modules/@injectivelabs/networks": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.11.0.tgz",
-      "integrity": "sha512-0dtO/zZ8AzsxGInEWZ7tpOA0Q++M3FhAFxOWzhYC39ZeJlwHhEcYmvmhrGG5gRdus29XfFysRlaz3hyT3XH1Jg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/networks/-/networks-1.14.0.tgz",
+      "integrity": "sha512-i1RzBUDSK/gGU6OCRr/oMcYXiBvNU0S6fMffxHXkRdZBv1VxD55bGwMmTfq1p2DaDCQGBc8VukSRmVOxmPtRyw==",
       "hasInstallScript": true,
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.11.0",
-        "@injectivelabs/ts-types": "^1.11.0",
-        "@injectivelabs/utils": "^1.11.0",
+        "@injectivelabs/exceptions": "^1.14.0",
+        "@injectivelabs/ts-types": "^1.14.0",
+        "@injectivelabs/utils": "^1.14.0",
         "link-module-alias": "^1.2.0",
         "shx": "^0.3.2"
       }
     },
     "node_modules/@injectivelabs/sdk-ts": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.11.0.tgz",
-      "integrity": "sha512-40WMqLKM+cwLB0M27hAg6MK1cnhlBi3H7ycDBXBs3CPLCuZJEyKiTGLWBLfnXAeSeYvVn80qS38Onu+XHNr7qQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/sdk-ts/-/sdk-ts-1.12.1.tgz",
+      "integrity": "sha512-OEbFb4W5D5tvC+sRkmb/+kbhD8hJ8GS8XiJPBV2k8DoNHmm+nHfHao/8sMTuvHDm2S+vZu3RrV7IBMRgZC64rw==",
       "hasInstallScript": true,
       "dependencies": {
         "@apollo/client": "^3.5.8",
@@ -1822,19 +1822,19 @@
         "@cosmjs/proto-signing": "^0.30.1",
         "@cosmjs/stargate": "^0.30.1",
         "@ethersproject/bytes": "^5.7.0",
-        "@injectivelabs/core-proto-ts": "^0.0.14",
+        "@injectivelabs/core-proto-ts": "^0.0.18",
         "@injectivelabs/dmm-proto-ts": "1.0.16",
-        "@injectivelabs/exceptions": "^1.11.0",
+        "@injectivelabs/exceptions": "^1.12.1",
         "@injectivelabs/grpc-web": "^0.0.1",
         "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
         "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-        "@injectivelabs/indexer-proto-ts": "1.10.8-rc.4",
-        "@injectivelabs/mito-proto-ts": "1.0.17",
-        "@injectivelabs/networks": "^1.11.0",
-        "@injectivelabs/test-utils": "^1.11.0",
-        "@injectivelabs/token-metadata": "^1.11.0",
-        "@injectivelabs/ts-types": "^1.11.0",
-        "@injectivelabs/utils": "^1.11.0",
+        "@injectivelabs/indexer-proto-ts": "1.11.9",
+        "@injectivelabs/mito-proto-ts": "1.0.43",
+        "@injectivelabs/networks": "^1.12.1",
+        "@injectivelabs/test-utils": "^1.12.1",
+        "@injectivelabs/token-metadata": "^1.12.1",
+        "@injectivelabs/ts-types": "^1.12.1",
+        "@injectivelabs/utils": "^1.12.1",
         "@metamask/eth-sig-util": "^4.0.0",
         "axios": "^0.27.2",
         "bech32": "^2.0.0",
@@ -2032,9 +2032,9 @@
       }
     },
     "node_modules/@injectivelabs/test-utils": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.11.0.tgz",
-      "integrity": "sha512-/KIPGeLFsjITs43yQG++SoOtDExZr+Pa3JVYIZEIMFUVG8a7z9Vi5m6a1kbowvozZbLG5KHuuUXF2SdfKSxznQ==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/test-utils/-/test-utils-1.14.0.tgz",
+      "integrity": "sha512-BeJ1W12rouZdbMrt91ufRBHz4WHOuJNEiDelBT78W/sYQd70EprLQcjkxNtDoW9NXt6wJvGrgwD8fBUzVD7XJw==",
       "hasInstallScript": true,
       "dependencies": {
         "axios": "^0.21.1",
@@ -2054,15 +2054,15 @@
       }
     },
     "node_modules/@injectivelabs/token-metadata": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/token-metadata/-/token-metadata-1.11.0.tgz",
-      "integrity": "sha512-RzwJvnjDX8IwXYTvZDCMQcGxkN/0ZfXUEYTVMB0WMU0bRH7cV7WJ6Z9UDOijAehrJHu/fByDz2DuEOcktbwoIw==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/token-metadata/-/token-metadata-1.14.0.tgz",
+      "integrity": "sha512-NJ4Xz4eakHXqNP6bTQzrmhX6FttahZWb1pJQC/xm2gTpecPhtzdUSdSw3hKCBUZPVQhUsN8OkI0QYY7iE8woTA==",
       "hasInstallScript": true,
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.11.0",
-        "@injectivelabs/networks": "^1.11.0",
-        "@injectivelabs/ts-types": "^1.11.0",
-        "@injectivelabs/utils": "^1.11.0",
+        "@injectivelabs/exceptions": "^1.14.0",
+        "@injectivelabs/networks": "^1.14.0",
+        "@injectivelabs/ts-types": "^1.14.0",
+        "@injectivelabs/utils": "^1.14.0",
         "@types/lodash.values": "^4.3.6",
         "copyfiles": "^2.4.1",
         "jsonschema": "^1.4.0",
@@ -2073,9 +2073,9 @@
       }
     },
     "node_modules/@injectivelabs/ts-types": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.11.0.tgz",
-      "integrity": "sha512-3ZVRW1xMe3RHOxFblRC0LgQcU/rpxgZQZ+sISyRKFGcS/m2ApkdmcPvjMgd5TQe9AXW/6nnvmul3mST8iAaUJg==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/ts-types/-/ts-types-1.14.0.tgz",
+      "integrity": "sha512-cXBAWGaKcP9qWB90GuwdKSOUEj0IQB3jGpeYHS0VWi2PgXi+m2+CWDP3B9qcCpDmEP6ERItZ8Qhbt+Px8dRfSQ==",
       "hasInstallScript": true,
       "dependencies": {
         "link-module-alias": "^1.2.0",
@@ -2083,13 +2083,13 @@
       }
     },
     "node_modules/@injectivelabs/utils": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.11.0.tgz",
-      "integrity": "sha512-KnUmt4vIvoBz6F3mQomy4GeTkpcHMYwju2AgiqzARrrqgF/2p1ZHfKBpr1ksj/jkl5X+irh3JVfbd/dFjwKi1g==",
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/@injectivelabs/utils/-/utils-1.14.0.tgz",
+      "integrity": "sha512-KzyuhrA5cZ845QC++2uxLd/rgf8/WlXYJbAqcM4XixFgx0ZKLxGauUrxNV3aUAqnV4QHKOfonRx6BYHCizEByQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@injectivelabs/exceptions": "^1.11.0",
-        "@injectivelabs/ts-types": "^1.11.0",
+        "@injectivelabs/exceptions": "^1.14.0",
+        "@injectivelabs/ts-types": "^1.14.0",
         "axios": "^0.21.1",
         "bignumber.js": "^9.0.1",
         "http-status-codes": "^2.2.0",
@@ -2592,9 +2592,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.195",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.195.tgz",
-      "integrity": "sha512-Hwx9EUgdwf2GLarOjQp5ZH8ZmblzcbTBC2wtQWNKARBSxM9ezRIAUpeDTgoQRAFB0+8CNWXVA9+MaSOzOF3nPg=="
+      "version": "4.14.199",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
+      "integrity": "sha512-Vrjz5N5Ia4SEzWWgIVwnHNEnb1UE1XMkvY5DGXrAeOGE9imk0hgTHh5GyDjLDJi9OTCn9oo9dXH1uToK1VRfrg=="
     },
     "node_modules/@types/lodash.values": {
       "version": "4.3.7",
@@ -3107,9 +3107,9 @@
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
     },
     "node_modules/bignumber.js": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-      "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
       "engines": {
         "node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@cosmjs/stargate": "^0.29.4",
     "@cosmjs/tendermint-rpc": "^0.29.4",
     "@injectivelabs/networks": "^1.0.105",
-    "@injectivelabs/sdk-ts": "^1.0.487",
+    "@injectivelabs/sdk-ts": "^1.12.1",
     "@injectivelabs/ts-types": "^1.0.39",
     "@skip-mev/skipjs": "1.1.0",
     "@slack/web-api": "^6.8.0",


### PR DESCRIPTION
Security upgrade @injectivelabs/sdk-ts from 1.11.0 to 1.12.1
Security upgrade node from 19 to 20.7

Changes to the following files to upgrade the vulnerable dependencies to a fixed version:
- package.json
- package-lock.json
- Dockerfile

https://www.cve.org/CVERecord?id=CVE-2021-30473
https://www.cve.org/CVERecord?id=CVE-2023-4863
https://www.cve.org/CVERecord?id=CVE-2023-36665